### PR TITLE
feat: Update service labels 1.0

### DIFF
--- a/azext_edge/edge/providers/support/dataprocessor.py
+++ b/azext_edge/edge/providers/support/dataprocessor.py
@@ -5,7 +5,7 @@
 # ----------------------------------------------------------------------------------------------
 
 from functools import partial
-from typing import Iterable, List
+from typing import Iterable
 
 from knack.log import get_logger
 
@@ -42,6 +42,7 @@ DATA_PROCESSOR_PVC_APP_LABELS = [
 
 DATA_PROCESSOR_LABEL = f"app in ({','.join(DATA_PROCESSOR_APP_LABELS)})"
 DATA_PROCESSOR_NAME_LABEL = "app.kubernetes.io/name in (dataprocessor)"
+DATA_PROCESSOR_INSTANCE_LABEL = "app.kubernetes.io/instance in (processor)"
 DATA_PROCESSOR_PVC_APP_LABEL = f"app in ({','.join(DATA_PROCESSOR_PVC_APP_LABELS)})"
 
 # TODO: @jiacju - will remove once the nats issue the fixed
@@ -73,7 +74,6 @@ def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
             ],
         )
     )
-
 
     return dataprocessor_pods
 
@@ -133,6 +133,12 @@ def fetch_persistent_volume_claims():
         process_persistent_volume_claims(
             resource_api=DATA_PROCESSOR_API_V1,
             label_selector=DATA_PROCESSOR_NAME_LABEL
+        )
+    )
+    processed.extend(
+        process_persistent_volume_claims(
+            resource_api=DATA_PROCESSOR_API_V1,
+            label_selector=DATA_PROCESSOR_INSTANCE_LABEL
         )
     )
     processed.extend(

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -44,6 +44,7 @@ MQ_LABEL = f"app in ({','.join(MQ_APP_LABELS)})"
 # TODO: @jiacju - this label will be used near future for consistency
 # MQ_NAME_LABEL = "app.kubernetes.io/name in (microsoft-iotoperations-mq)"
 
+
 def fetch_diagnostic_metrics(namespace: str):
     # @digimaun - TODO dynamically determine pod:port
     try:

--- a/azext_edge/edge/providers/support/mq.py
+++ b/azext_edge/edge/providers/support/mq.py
@@ -41,6 +41,8 @@ MQ_APP_LABELS = [
 
 MQ_LABEL = f"app in ({','.join(MQ_APP_LABELS)})"
 
+# TODO: @jiacju - this label will be used near future for consistency
+# MQ_NAME_LABEL = "app.kubernetes.io/name in (microsoft-iotoperations-mq)"
 
 def fetch_diagnostic_metrics(namespace: str):
     # @digimaun - TODO dynamically determine pod:port

--- a/azext_edge/edge/providers/support/opcua.py
+++ b/azext_edge/edge/providers/support/opcua.py
@@ -29,6 +29,9 @@ OPC_APP_LABEL = "app in (aio-opc-supervisor, aio-opc-admission-controller)"
 OPC_NAME_LABEL = "app.kubernetes.io/name in (aio-opc-opcua-connector, opcplc)"
 OPC_NAME_VAR_LABEL = "name in (aio-opc-asset-discovery)"
 
+# TODO: once this label is stabled, we can remove the other labels
+OPCUA_NAME_LABEL = "app.kubernetes.io/name in (microsoft-iotoperations-opcuabroker)"
+
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
     opcua_pods = process_v1_pods(
@@ -53,23 +56,35 @@ def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
             include_metrics=True,
         )
     )
+    opcua_pods.extend(
+        process_v1_pods(
+            resource_api=OPCUA_API_V1,
+            label_selector=OPCUA_NAME_LABEL,
+            since_seconds=since_seconds,
+            include_metrics=True,
+        )
+    )
     return opcua_pods
 
 
 def fetch_deployments():
     processed = process_deployments(resource_api=OPCUA_API_V1, prefix_names=[OPC_PREFIX, SIMULATOR_PREFIX])
+    processed.extend(process_deployments(resource_api=OPCUA_API_V1, label_selector=OPC_NAME_LABEL))
+    processed.extend(process_deployments(resource_api=OPCUA_API_V1, label_selector=OPCUA_NAME_LABEL))
     return processed
 
 
 def fetch_replicasets():
     processed = process_replicasets(resource_api=OPCUA_API_V1, label_selector=OPC_APP_LABEL)
     processed.extend(process_replicasets(resource_api=OPCUA_API_V1, label_selector=OPC_NAME_LABEL))
+    processed.extend(process_replicasets(resource_api=OPCUA_API_V1, label_selector=OPCUA_NAME_LABEL))
     return processed
 
 
 def fetch_services():
     processed = process_services(resource_api=OPCUA_API_V1, label_selector=OPC_APP_LABEL)
     processed.extend(process_services(resource_api=OPCUA_API_V1, prefix_names=[SIMULATOR_PREFIX]))
+    processed.extend(process_services(resource_api=OPCUA_API_V1, label_selector=OPCUA_NAME_LABEL))
     return processed
 
 
@@ -77,6 +92,12 @@ def fetch_daemonsets():
     processed = process_daemonsets(
         resource_api=OPCUA_API_V1,
         field_selector="metadata.name==aio-opc-asset-discovery",
+    )
+    processed.extend(
+        process_daemonsets(
+            resource_api=OPCUA_API_V1,
+            label_selector=OPCUA_NAME_LABEL,
+        )
     )
     return processed
 

--- a/azext_edge/edge/providers/support/orc.py
+++ b/azext_edge/edge/providers/support/orc.py
@@ -26,6 +26,9 @@ ORC_INSTANCE_LABEL = "app.kubernetes.io/instance in (azure-iot-operations)"
 ORC_APP_LABEL = "app in (aio-orc-api)"
 ORC_CONTROLLER_LABEL = "control-plane in (aio-orc-controller-manager)"
 
+# TODO: @jiacju - this label will be used near future for consistency
+# META_AIO_NAME_LABEL = "app.kubernetes.io/name in (microsoft-iotoperations)"
+
 
 def fetch_pods(since_seconds: int = DAY_IN_SECONDS):
     processed = process_v1_pods(

--- a/azext_edge/tests/edge/support/conftest.py
+++ b/azext_edge/tests/edge/support/conftest.py
@@ -220,6 +220,26 @@ def mocked_get_custom_objects(mocker):
 
 
 @pytest.fixture
+def mocked_namespaced_custom_objects(mocked_client):
+    def _handle_namespaced_custom_object(*args, **kwargs):
+        custom_object = {
+            'kind': 'PodMetrics',
+            'apiVersion': 'metrics.k8s.io/v1beta1',
+            'metadata': {
+                'name': 'mock_custom_object',
+                'namespace': 'namespace',
+                'creationTimestamp': '0000-00-00T00:00:00Z',
+            },
+            'timestamp': '0000-00-00T00:00:00Z'
+        }
+
+        return custom_object
+
+    mocked_client.CustomObjectsApi().get_namespaced_custom_object.side_effect = _handle_namespaced_custom_object
+    yield mocked_client
+
+
+@pytest.fixture
 def mocked_list_deployments(mocked_client):
     from kubernetes.client.models import V1DeploymentList, V1Deployment, V1ObjectMeta
 


### PR DESCRIPTION
There will be further updates according to the aio template update, but here is the changes now:
1.	OPC UA label need to update✅
2.	Akri missing pod: aio-akri-agent-daemonset-6m9cz (app.kubernetes.io/name:aio-akri-agent)
aio-akri-webhook-configuration-7cb4d6c4f7-45mnh(app.kubernetes.io/name:aio-akri-webhook-configuration)
Missing deployment: aio-akri-webhook-configuration(app.kubernetes.io/name:aio-akri-webhook-configuration)
Missing Daemonset: aio-akri-agent-daemonset(app.kubernetes.io/name:aio-akri-agent)
Missing Service: aio-akri-webhook-configuration(app.kubernetes.io/name:aio-akri-webhook-configuration)
Missing Replicaset: aio-akri-webhook-configuration-7cb4d6c4f7(app.kubernetes.io/name:aio-akri-webhook-configuration) ✅
3.	Dp label need to update and add app label for nats(because nats will not have consistent label for april release)✅
4.	Add unit test for include_metrics variable✅

---
This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.

Thank you for contributing to Azure IoT Operations tooling!

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

Intent for Production

- [ ] It is expected that pull requests made to default or core branches such as `dev` or `main` are of production grade. Corollary to this, any merged contributions to these branches may be deployed in a public release at any given time. By checking this box, you agree and commit to the expected production quality of code.

Basic expectations

- [ ] If introducing new functionality or modified behavior, are they backed by unit and/or integration tests?
- [ ] In the same context as above are command names and their parameter definitions accurate? Do help docs have sufficient content?
- [ ] Have **all** the relevant unit **and** integration tests pass? i.e. `pytest <project root> -vv`. Please provide evidence in the form of a screenshot showing a succesful run of tests locally OR a link to a test pipeline that has been run against the change-set.
- [ ] Have linter checks passed using the `.pylintrc` and `.flake8` rules? Look at the CI scripts for example usage.
- [ ] Have extraneous print or debug statements, commented out code-blocks or code-statements (if any) been removed from the surface area of changes?
- [ ] Have you made an entry in HISTORY.rst which concisely explains your user-facing feature or change?

Azure IoT Operations CLI maintainers reserve the right to enforce any of the outlined expectations.

A PR is considered **ready for review** when all basic expectations have been met (or do not apply).
